### PR TITLE
Fix dag-factory documentation links in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -221,7 +221,7 @@ ENVIRONMENT=development
 
 ### DAG Factory Configuration
 
-Refer to the [dag-factory documentation](https://dag-factory.readthedocs.io/) for advanced configuration options.
+Refer to the [dag-factory documentation](https://astronomer.github.io/dag-factory/latest/getting-started/quick-start-airflow-standalone/) for advanced configuration options.
 
 ## Known Limitations
 
@@ -244,5 +244,5 @@ This project is licensed under the MIT License - see the [LICENSE](LICENSE) file
 ## Resources
 
 - [Apache Airflow Documentation](https://airflow.apache.org/docs/)
-- [dag-factory Documentation](https://dag-factory.readthedocs.io/)
+- [dag-factory Documentation](https://astronomer.github.io/dag-factory/latest/getting-started/quick-start-airflow-standalone/)
 - [Docker Compose for Airflow](https://airflow.apache.org/docs/apache-airflow/stable/howto/docker-compose/index.html)


### PR DESCRIPTION
## Overview
Fixes broken dag-factory documentation links in the README that were pointing to an outdated URL.

## Changes
- Updated `dag-factory.readthedocs.io` links to the correct Astronomer documentation URL
- Ensures users can access current dag-factory documentation and examples
- Fixes both the DAG Factory Configuration section and Resources section

## Why This Fix Is Needed
The old readthedocs.io links were returning 404 errors, preventing users from accessing the official dag-factory documentation and getting started with the project.

## Testing
- Verified the new links work correctly and point to the current documentation
- Links now properly direct to Astronomer's hosted dag-factory documentation